### PR TITLE
Update EmplyJobsService.cs

### DIFF
--- a/src/Limbo.Umbraco.Emply/Services/EmplyJobsService.cs
+++ b/src/Limbo.Umbraco.Emply/Services/EmplyJobsService.cs
@@ -309,7 +309,7 @@ public class EmplyJobsService {
         // node name that is too long
         int maxLength = 255 - item.JobId.ToString().Length - 3;
         string nodeName = $"{item.Title.ToString().Trim()} ({item.JobId})";
-        if (nodeName.Length > maxLength) nodeName = $"{nodeName[..(maxLength - 3)]} ({{item.JobId})...";
+        if (nodeName.Length > maxLength) nodeName = $"{nodeName[..(maxLength - 3)]} ({item.JobId})...";
 
         try {
 

--- a/src/Limbo.Umbraco.Emply/Services/EmplyJobsService.cs
+++ b/src/Limbo.Umbraco.Emply/Services/EmplyJobsService.cs
@@ -309,7 +309,7 @@ public class EmplyJobsService {
         // node name that is too long
         int maxLength = 255 - item.JobId.ToString().Length - 3;
         string nodeName = $"{item.Title.ToString().Trim()} ({item.JobId})";
-        if (nodeName.Length > maxLength) nodeName = $"{nodeName[..(maxLength - 3)]}...";
+        if (nodeName.Length > maxLength) nodeName = $"{nodeName[..(maxLength - 3)]} ({{item.JobId})...";
 
         try {
 


### PR DESCRIPTION
I think this should be change so the nodeName still contains the jobId. If done like this it should still only be 255 chars long.